### PR TITLE
Add a note about opening port 3074 in the server setup guide.

### DIFF
--- a/src/pages/docs/server/t6/setting-up-a-server.md
+++ b/src/pages/docs/server/t6/setting-up-a-server.md
@@ -55,7 +55,7 @@ You don't need the video & sound folders, the .ipak files nor the SP level files
 
 ## Port Forwarding
 
-Hosting a game server requires you to port forward to make your server accessible from outside of your network. Since every router is different we can't make a guide for every router so we recommend searching "your router name + port forward" on Google. **Port forward the port you specified in your start.bat file.**
+Hosting a game server requires you to port forward to make your server accessible from outside of your network. Since every router is different we can't make a guide for every router so we recommend searching "your router name + port forward" on Google. **Port forward the port you specified in your start.bat file. If your NAT type isn't "Open", you will also need to port forward port `3074`.**
 
 You will also need to add the port to your Windows Firewall, refer to this [Tom's Hardware article](https://www.tomshardware.com/news/how-to-open-firewall-ports-in-windows-10,36451.html).
 


### PR DESCRIPTION
This may be basic info to people experienced with BO2 so they may have already opened 3074 to set their NAT type to Open, but I first played BO2 through Pluto, so 3074 was closed, and the server appeared to be functioning normally aside from it not appearing in the server list or being able to be connected to manually. Opening 3074 instantly made the server appear in the server list and made it connectable.