### PR TITLE
'contributing a translation' button now directs to the correct github…

### DIFF
--- a/src/components/DocsLayout.js
+++ b/src/components/DocsLayout.js
@@ -21,9 +21,8 @@ const DocsLayout = ({ children, path, anchors, autoTranslated, description }) =>
     const newTranslationUrl = useMemo(
         () =>
             GITHUB_PREFIX +
-            'new/develop/' +
-            dirname(path) +
-            '?filename=' +
+            'new/develop?filename=' +
+            `${dirname(path)}/` +
             basename(path, extname(path)) +
             `.${locale}` +
             extname(path),


### PR DESCRIPTION
… directory (as opposed to going up a level) to create a new file

Closes #121.